### PR TITLE
Empty array will be returned, if $key is not in the array.

### DIFF
--- a/src/Store.php
+++ b/src/Store.php
@@ -90,7 +90,9 @@ class Store
     public function getNamedAry(string $key): array
     {
         $ary = $this->getNamedT();
-
+        if (!array_key_exists($key, $ary)) {
+            return [];
+        }
         return $ary[$key];
     }
 

--- a/tests/StoreTest.php
+++ b/tests/StoreTest.php
@@ -190,6 +190,9 @@ class StoreTest extends TestCase
         $a = self::$BASIC_ARY;
         $s = new Store($a, ['columns' => ['a'], 'others' => 'b']);
         $this->assertEquals($s->getNamedAry('a'), [1, 4, 7]);
+
+        // Empty array will be returned, if $key is not in the array.
+        $this->assertEquals($s->getNamedAry('not_exist'), []);
     }
 
     public function provideNamedT()


### PR DESCRIPTION
When unknown $key is provided to the method `getNamedAry`, the method return null.
This behavior is bug, so it was fixed.